### PR TITLE
Changes for running on Windows

### DIFF
--- a/book_to_txt.py
+++ b/book_to_txt.py
@@ -17,6 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import re
+import shutil
 import sys
 import time
 import textract
@@ -72,15 +73,13 @@ def extract_text_from_book_using_calibre(book_path):
     if not validate_book_path(book_path):
         raise ValueError(f"Invalid or unsafe book path: {book_path}")
         
-    # Get ebook-convert binary path securely
-    allowed_commands = ['which']
-    ebook_convert_bin_result = run_shell_command_secure("which ebook-convert", allowed_commands)
-    
-    if not ebook_convert_bin_result or not ebook_convert_bin_result.stdout.strip():
+    # Get ebook-convert binary path
+    ebook_convert_bin_result = shutil.which("ebook-convert")
+    if not ebook_convert_bin_result or not os.path.exists(ebook_convert_bin_result.strip()):
         raise RuntimeError("ebook-convert command not found")
         
-    ebook_convert_bin_path = ebook_convert_bin_result.stdout.strip()
-
+    ebook_convert_bin_path = ebook_convert_bin_result.strip()
+    
     # Build secure command as list
     command = [ebook_convert_bin_path, book_path, "extracted_book.txt"]
     

--- a/generate_audiobook.py
+++ b/generate_audiobook.py
@@ -56,6 +56,7 @@ def sanitize_filename(text):
     text = text.replace("'", '').replace('"', '').replace('/', ' ').replace('.', ' ')
     text = text.replace(':', '').replace('?', '').replace('\\', '').replace('|', '')
     text = text.replace('*', '').replace('<', '').replace('>', '').replace('&', 'and')
+    text = text.replace(',', ' ').replace('-', ' ')
     
     # Normalize whitespace and trim
     text = ' '.join(text.split())
@@ -998,7 +999,7 @@ async def main():
         print("\n⚠️ Invalid option! Please restart and enter either **1** or **2**.")
         return
 
-    print(f"\n🎧 Audiobook is generated ! The audiobook is saved as **audiobook.{"m4b" if generate_m4b_audiobook_file else output_format}** in the **generated_audiobooks** directory in the current folder.")
+    print(f"\n🎧 Audiobook is generated ! The audiobook is saved as **audiobook.{'m4b' if generate_m4b_audiobook_file else output_format}** in the **generated_audiobooks** directory in the current folder.")
 
     end_time = time.time()
 

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -48,7 +48,7 @@ nvidia-curand-cu12==10.3.5.147
 nvidia-cusolver-cu12==11.6.1.9
 nvidia-cusparse-cu12==12.3.1.170
 nvidia-cusparselt-cu12==0.6.2
-nvidia-nccl-cu12==2.21.5
+nvidia-nccl-cu12==2.21.5; sys_platform == 'linux'
 nvidia-nvjitlink-cu12==12.4.127
 nvidia-nvtx-cu12==12.4.127
 olefile==0.47
@@ -96,7 +96,8 @@ tomlkit==0.13.2
 torch==2.6.0
 tqdm==4.67.1
 transformers==4.49.0
-triton==3.2.0
+triton==3.2.0; sys_platform != 'win32'
+triton-windows==3.2.0.post19; sys_platform == 'win32'
 typer==0.15.2
 typing-extensions==4.12.2
 tzdata==2025.1

--- a/utils/add_emotion_tags_to_text.py
+++ b/utils/add_emotion_tags_to_text.py
@@ -668,7 +668,8 @@ async def add_tags_to_text_chunks(text_to_process):
         with open("tag_added_lines_chunks.txt", "w") as f:
             f.write(enhanced_text)
         yield f"Emotion tags processing completed. Output written to tag_added_lines_chunks.txt"
-        yield f"Line count verification: Filtered={len(non_empty_lines)}, Enhanced={len(enhanced_text.split('\n'))}"
+        enhanced_text_split = enhanced_text.split('\n')
+        yield f"Line count verification: Filtered={len(non_empty_lines)}, Enhanced={len(enhanced_text_split)}"
     except IOError as e:
         yield f"Error writing output file: {e}"
         traceback.print_exc()

--- a/utils/audiobook_utils.py
+++ b/utils/audiobook_utils.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import subprocess
 import re
 import os
+import shutil
 import traceback
 import shlex
 import json
@@ -70,14 +71,12 @@ def get_ebook_metadata_with_cover(book_path):
     if not validate_file_path(book_path):
         raise ValueError(f"Invalid or unsafe book path: {book_path}")
         
-    # Get ebook-meta binary path securely
-    allowed_commands = ['which', 'ebook-meta']
-    ebook_meta_bin_result = run_shell_command_secure("which ebook-meta", allowed_commands)
-    
-    if not ebook_meta_bin_result or not ebook_meta_bin_result.stdout.strip():
+    # Get ebook-meta binary path
+    ebook_meta_bin_result = shutil.which("ebook-meta")
+    if not ebook_meta_bin_result or not os.path.exists(ebook_meta_bin_result.strip()):
         raise RuntimeError("ebook-meta command not found")
         
-    ebook_meta_bin_path = ebook_meta_bin_result.stdout.strip()
+    ebook_meta_bin_path = ebook_meta_bin_result.strip()
 
     # Build secure command as list
     command = [ebook_meta_bin_path, book_path, "--get-cover", "cover.jpg"]


### PR DESCRIPTION
Rebased to 1.5
These changes allow to run on Windows without docker.

Please check that I haven't broken Linux support. 
The commands below should also work for linux just the environment ones ($Env:*) would need to be changed.

These assume uv is installed. https://docs.astral.sh/uv/getting-started/installation/
And the default port 8880 is used by Kokoro in the start-gpu.ps1 so 8881 is used instead.
```
# Running Kokoro using gpu
cd <path>\Kokoro-FastAPI
.\start-gpu.ps1
```

Basic terminal (powershell) commands to setup to run:
```
cd <path>\audiobook-creator
uv python install 3.10
uv venv --python 3.10
uv pip install -U -r requirements_gpu.txt --index-strategy unsafe-best-match --extra-index-url https://download.pytorch.org/whl/cu126
uv pip install six==1.17.0
```

Basic terminal (powershell) commands to run the webui:
Assuming Calibre and ffmpeg are installed in the shown locations. Change or remove the path variable.
```
cd <path>\audiobook-creator
$Env:PATH = "$Env:PATH;C:\Program Files\Calibre2;C:\ffmpeg"
$Env:PROJECT_ROOT = "$pwd"
$Env:PYTHONPATH = "$Env:PROJECT_ROOT/app"
uv run uvicorn --access-log app:app --host 127.0.0.1 --port 8881

```
Access the webui on http://127.0.0.1:8881