### PR TITLE
Fix: Add libnss3 dependency to fix Calibre PDF conversion in Docker

### DIFF
--- a/docker/cpu/Dockerfile
+++ b/docker/cpu/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     libegl1 \
     libopengl0 \
     libxcb-cursor0 \
+    libnss3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv package manager

--- a/docker/gpu/Dockerfile
+++ b/docker/gpu/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     libegl1 \
     libopengl0 \
     libxcb-cursor0 \
+    libnss3 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv package manager


### PR DESCRIPTION
When using Calibre for PDF text extraction in the Docker container, the conversion fails due to missing libnss3 library. This change adds the required dependency to both CPU and GPU Dockerfiles.

The error was:
calibre.ebooks.ConversionError: pdftohtml failed with return code: 127 /opt/calibre/bin/pdftohtml: error while loading shared libraries: libnss3.so